### PR TITLE
Fix variable rendering broken by Joplin's isolated renderer context

### DIFF
--- a/plugin.config.json
+++ b/plugin.config.json
@@ -1,3 +1,3 @@
 {
-	"extraScripts": ["markdownItPlugin.ts"]
+  "extraScripts": ["markdownItPlugin.ts"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "id": "com.DanteCoder.NoteVariables",
   "app_min_version": "2.2",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "name": "Note Variables",
   "description": "A plugin to create variables that can be accesed through all the notes.",
   "author": "Dante G. Barboza",

--- a/src/markdownItPlugin.ts
+++ b/src/markdownItPlugin.ts
@@ -1,137 +1,49 @@
-import { debounce } from './utils/debounce';
-
-let importedVariables: { [key: string]: string } = null;
-let noteVariables: { [note: string]: { vars: { [key: string]: string } } } = {};
+// Markdown-It content script for Note Variables.
+//
+// IMPORTANT ARCHITECTURE NOTE:
+// markdown-it render rules run at render time but produce static HTML. They
+// cannot call webviewApi (that only exists in the rendered webview). So the
+// rules here only EMIT markup + data attributes. The actual variable lookup
+// and substitution happens in the runtime asset (noteVariablesRuntime.js),
+// which runs inside the webview and uses webviewApi.postMessage to ask the
+// plugin's main process for the current variables.
 
 export default function (context) {
+  const contentScriptId = context.contentScriptId;
+
   return {
     plugin: function (markdownIt, _options) {
-      const defaultRender =
-        markdownIt.renderer.rules.text ||
-        function (tokens, idx, options, env, self) {
-          return self.renderToken(tokens, idx, options, env, self);
-        };
-
       const defaultInlineCodeRender =
         markdownIt.renderer.rules.code_inline ||
         function (tokens, idx, options, env, self) {
           return self.renderToken(tokens, idx, options, env, self);
         };
 
-      /**
-       * Searchs for Note Variable imports
-       */
       markdownIt.renderer.rules.code_inline = function (tokens, idx, options, env, self) {
         const token = tokens[idx];
 
         const importMatch = (token.content as string)?.match(/^import((?:\s[^%\s]+)+)$/);
-        const imports = importMatch
-          ? importMatch[1]
-              .trimStart()
-              .split(' ')
-              .map(i => '%' + i + '%')
-          : [];
+        if (importMatch == null) {
+          return defaultInlineCodeRender(tokens, idx, options, env, self);
+        }
 
-        if (importMatch == null) return defaultInlineCodeRender(tokens, idx, options, env, self);
+        const importNames = importMatch[1]
+          .trimStart()
+          .split(' ')
+          .map(i => '%' + i + '%');
 
-        noteVariables = fetchLocalStoargeVariables();
-        const importResult = mergeImports(imports);
-        importedVariables = importResult.merged;
-
-        const newText =
-          '<code class="inline-code">import' +
-          imports
-            .map(value => {
-              const successImport = importResult.validImports.includes(value);
-              return `<span style="color:${successImport ? 'lightgreen' : 'lightcoral'}" > ${value}</span>`;
-            })
-            .join('') +
-          '</code>';
-
-        return newText;
-      };
-
-      /**
-       * Replaces the imported variables into the text
-       */
-      markdownIt.renderer.rules.text = function (tokens, idx, options, env, self) {
-        if (importedVariables == null) return defaultRender(tokens, idx, options, env, self);
-        const token = tokens[idx];
-        const text = <string>token.content;
-
-        // Replace the variables in the text
-        const newText = replaceText(text, importedVariables);
-        resetImportedVariables();
-        return newText;
+        // Emit a marker the runtime can find. The runtime fills in colors and
+        // performs the text substitution after fetching variables.
+        const escaped = markdownIt.utils.escapeHtml(JSON.stringify(importNames));
+        return (
+          `<code class="inline-code note-variables-import" ` +
+          `data-content-script-id="${markdownIt.utils.escapeHtml(contentScriptId)}" ` +
+          `data-import-names="${escaped}">import ${markdownIt.utils.escapeHtml(importNames.join(' '))}</code>`
+        );
       };
     },
+    assets: function () {
+      return [{ name: 'noteVariablesRuntime.js' }];
+    },
   };
-}
-
-/**
- * Fetch the note variables from local storage.
- * @returns The Note Variables from local storage
- */
-function fetchLocalStoargeVariables() {
-  const jsonStrong = localStorage.getItem('NoteVariables');
-  if (jsonStrong == null) return {};
-  const noteVariables = JSON.parse(jsonStrong);
-
-  return noteVariables;
-}
-
-/**
- * Merges the Note Variables into a single object to use in the MD renderer
- * @param imports
- * @returns The merged variables and the valid imports
- */
-function mergeImports(imports: string[]) {
-  let result = { merged: {}, validImports: [] };
-
-  // The reverse is to give the first imports variables more priority
-  [...imports].reverse().forEach(importValue => {
-    if (noteVariables[importValue] == null) return;
-    result.validImports.push(importValue);
-    result.merged = {
-      ...result.merged,
-      ...noteVariables[importValue].vars,
-    };
-  });
-
-  return result;
-}
-
-/**
- * Resets the imported variables.
- */
-const resetImportedVariables = debounce(() => {
-  importedVariables = null;
-}, 500);
-
-/**
- * Replaces all the provided variables in a string
- * @param text
- * @param variables
- * @returns The replaced text
- */
-function replaceText(text: string, variables: { [key: string]: string }): string {
-  if (text.length === 0) return '';
-  const varKeys = Object.keys(variables);
-  if (varKeys.length === 0) return text;
-
-  const variablesLeft = { ...variables };
-
-  for (const key of varKeys) {
-    delete variablesLeft[key];
-    const matchIndex = text.indexOf(key);
-    if (matchIndex === -1) continue;
-
-    const textSplit = text.split(key).map(splitText => {
-      return replaceText(splitText, variablesLeft);
-    });
-
-    return textSplit.join(variables[key]);
-  }
-
-  return text;
 }

--- a/src/noteVariables.ts
+++ b/src/noteVariables.ts
@@ -3,26 +3,41 @@ import { ContentScriptType, MenuItemLocation } from 'api/types';
 import { createVariablesNote } from './utils/createVariablesNote';
 import { loadVariablesNotes } from './utils/loadVariablesNotes';
 
+const CONTENT_SCRIPT_ID = 'noteVariablesMD';
+
 export namespace noteVariables {
   /**
-   * Loads all the variables from the Notes into localStorage for the MD plugin
-   * @param e
+   * Reloads variables whenever a variables-note (title like "%Name%") changes.
    */
   const onNoteChangeHandler = async (e: any) => {
     if (e.event !== 2) return;
     const note = await joplin.data.get(['notes', e.id], { fields: ['title'] });
     if (note.title.match(/^\%[^%]*\%$/) == null) return;
-    loadVariablesNotes();
+    await loadVariablesNotes();
   };
 
   export async function init() {
     await joplin.contentScripts.register(
       ContentScriptType.MarkdownItPlugin,
-      'noteVariablesMD',
+      CONTENT_SCRIPT_ID,
       './markdownItPlugin.js'
     );
+
+    // The Markdown content script runs in a sandboxed context and cannot read
+    // the plugin's storage directly. It requests the current variables via
+    // postMessage; we answer with the in-memory cache maintained by
+    // loadVariablesNotes().
+    await joplin.contentScripts.onMessage(CONTENT_SCRIPT_ID, (message: any) => {
+      if (message && message.name === 'getNoteVariables') {
+        return loadVariablesNotes.getCache();
+      }
+      return null;
+    });
+
     await joplin.workspace.onNoteChange(onNoteChangeHandler);
-    await joplin.workspace.onNoteSelectionChange(loadVariablesNotes);
+    await joplin.workspace.onNoteSelectionChange(async () => {
+      await loadVariablesNotes();
+    });
 
     await joplin.commands.register({
       name: 'newVariablesNote',
@@ -33,7 +48,7 @@ export namespace noteVariables {
         createVariablesNote(folder.id);
       },
     });
-    await joplin.views.menuItems.create('Create variables vote', 'newVariablesNote', MenuItemLocation.Note);
+    await joplin.views.menuItems.create('Create variables note', 'newVariablesNote', MenuItemLocation.Note);
 
     await loadVariablesNotes();
   }

--- a/src/noteVariablesRuntime.js
+++ b/src/noteVariablesRuntime.js
@@ -1,0 +1,124 @@
+// Runtime script executed INSIDE the Joplin markdown viewer webview.
+// Self-executing: runs on load and re-runs after every note render
+// (Joplin dispatches 'joplin-noteDidUpdate' on the document after rendering).
+//
+// It asks the plugin's main process for the current variables via
+// webviewApi.postMessage, then recolors the import markers and substitutes
+// variable values into the rendered note text.
+
+(function () {
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  async function process() {
+    if (typeof webviewApi === 'undefined' || !webviewApi.postMessage) return;
+
+    var markers = Array.prototype.slice.call(
+      document.querySelectorAll('code.note-variables-import:not([data-nv-done])')
+    );
+    if (markers.length === 0) return;
+
+    var contentScriptId = markers[0].getAttribute('data-content-script-id');
+    if (!contentScriptId) return;
+
+    var groups;
+    try {
+      groups = await webviewApi.postMessage(contentScriptId, { name: 'getNoteVariables' });
+    } catch (e) {
+      return;
+    }
+    if (!groups || typeof groups !== 'object') groups = {};
+
+    var merged = {};
+    markers.forEach(function (marker) {
+      var names = [];
+      try {
+        names = JSON.parse(marker.getAttribute('data-import-names') || '[]');
+      } catch (e) {
+        names = [];
+      }
+
+      // Earlier imports take priority: apply in reverse so first wins.
+      names.slice().reverse().forEach(function (name) {
+        if (groups[name] && groups[name].vars) {
+          for (var k in groups[name].vars) {
+            if (Object.prototype.hasOwnProperty.call(groups[name].vars, k)) {
+              merged[k] = groups[name].vars[k];
+            }
+          }
+        }
+      });
+
+      var spans = names
+        .map(function (name) {
+          var ok = !!(groups[name] && groups[name].vars);
+          var color = ok ? 'lightgreen' : 'lightcoral';
+          return '<span style="color:' + color + '"> ' + escapeHtml(name) + '</span>';
+        })
+        .join('');
+      marker.innerHTML = 'import' + spans;
+      marker.setAttribute('data-nv-done', '1');
+    });
+
+    var keys = Object.keys(merged);
+    if (keys.length === 0) return;
+
+    var root = document.getElementById('rendered-md') || document.body;
+    if (!root) return;
+
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        var el = node.parentElement;
+        while (el) {
+          if (el.classList && el.classList.contains('note-variables-import')) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          if (el.tagName === 'PRE' || el.tagName === 'CODE') {
+            // allow our marker (handled above) but skip other code/pre
+            if (!(el.classList && el.classList.contains('note-variables-import'))) {
+              return NodeFilter.FILTER_REJECT;
+            }
+          }
+          el = el.parentElement;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+
+    var textNodes = [];
+    var current = walker.nextNode();
+    while (current) {
+      textNodes.push(current);
+      current = walker.nextNode();
+    }
+
+    textNodes.forEach(function (node) {
+      var text = node.nodeValue;
+      var changed = false;
+      keys.forEach(function (key) {
+        if (text.indexOf(key) !== -1) {
+          text = text.split(key).join(merged[key]);
+          changed = true;
+        }
+      });
+      if (changed) node.nodeValue = text;
+    });
+  }
+
+  function run() {
+    process().catch(function () {});
+  }
+
+  // Run now (in case the note is already rendered) and on every re-render.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+  document.addEventListener('joplin-noteDidUpdate', run);
+})();

--- a/src/utils/loadVariablesNotes.ts
+++ b/src/utils/loadVariablesNotes.ts
@@ -2,6 +2,14 @@ import joplin from 'api';
 import { findVariablesNotes } from './findVariablesNotes';
 import { parseNote } from './parseNote';
 
+type VariableGroups = { [note: string]: { vars: { [key: string]: string } } };
+
+// In-memory cache of the most recently loaded variable groups. The Markdown
+// content script reads this via postMessage (see noteVariables.ts), replacing
+// the old localStorage bridge that no longer works across Joplin's isolated
+// rendering context.
+let cache: VariableGroups = {};
+
 export const loadVariablesNotes = async () => {
   const notes = await findVariablesNotes();
 
@@ -11,7 +19,7 @@ export const loadVariablesNotes = async () => {
     })
   );
 
-  const variableGroups: any = {};
+  const variableGroups: VariableGroups = {};
 
   notesData.forEach(note => {
     if (variableGroups[note.title] != null) return;
@@ -21,6 +29,9 @@ export const loadVariablesNotes = async () => {
     };
   });
 
-  localStorage.setItem('NoteVariables', JSON.stringify(variableGroups));
-  localStorage.setItem('UpdateNoteVariablesMDP', 'true');
+  cache = variableGroups;
+  return cache;
 };
+
+// Synchronous accessor used by the content-script message handler.
+loadVariablesNotes.getCache = (): VariableGroups => cache;


### PR DESCRIPTION
**Fix**

- Replaced the `localStorage` bridge with Joplin's supported `contentScripts.onMessage` / `webviewApi.postMessage` channel. Variables are now held in an in-memory cache and requested by the renderer.
- Added a webview runtime script (src/noteVariablesRuntime.js) that fetches variables, recolors the import markers, and substitutes values into the rendered text.
- Made the runtime self-executing and hooked it to joplin-noteDidUpdate so it runs on every render.

Variable syntax, table format, and %Name% conventions are unchanged. Also fixes a minor typo in the menu label ("vote" → "note").

**Testing**

Built and installed on Joplin 3.6.14 (macOS); imports turn green and values substitute correctly.
Developed with AI assistance. I diagnosed the issue, tested each iteration, and confirmed the final build works. Happy to adjust the approach.